### PR TITLE
Fix build issues on modern Linux systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 selfTest
 simplexSelfTest
 sparsetest
+quocELMA/external
+quocELMA/internal
+quocELMA/examples

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+*.o
+*.a
+Makefile
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+cmake_install.cmake
+CTestTestfile.cmake
+build
+
+selfTest
+simplexSelfTest
+sparsetest

--- a/quocELMA/go.sh
+++ b/quocELMA/go.sh
@@ -1,4 +1,2 @@
-#!/bin/bash
-export CC=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
-export CXX=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang
+#!/bin/sh
 cmake -G"Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DUSE_BOOST=1 -DDYNAMIC_LINKING=0 -DPARSE_GCC_ERRORS=1 -DUSE_BLAS=1 -DUSE_LAPACK=1 -DUSE_QT=1 -DBUILD_AND_USE_KISSFFT=1 -DUSE_PNG=1 -DUSE_TIFF=1 -DUSE_C++11=1 -DELMA_DEPLOY=1 ../quocmesh

--- a/quocmesh/CMakeLists.txt
+++ b/quocmesh/CMakeLists.txt
@@ -100,7 +100,7 @@ IF ( CMAKE_COMPILER_IS_GNUCXX )
 
   ADD_DEFINITIONS ( -fmessage-length=0 -DGNU -Wcast-qual -Wall -Wextra -Wno-conversion -Winit-self -Wcast-align -Wundef -Wswitch-default -Wredundant-decls -pedantic )
   # The following flags are only valid for C++.
-  SET ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Woverloaded-virtual -Wnon-virtual-dtor" )
+  SET ( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast -Woverloaded-virtual -Wnon-virtual-dtor -fext-numeric-literals" )
   IF ( NOT MINGW )
     ADD_DEFINITIONS ( -fPIC -ansi )
 

--- a/quocmesh/CMakeLists.txt
+++ b/quocmesh/CMakeLists.txt
@@ -4,6 +4,9 @@
 CMAKE_MINIMUM_REQUIRED ( VERSION 2.8 )
 
 PROJECT ( quocmesh )
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 11)
+
 
 ENABLE_TESTING()
 
@@ -90,7 +93,6 @@ IF ( CMAKE_COMPILER_IS_GNUCXX )
   OPTION ( PARSE_GCC_ERRORS "Make cmake use our GCC error parsing script like colorize.pl" ON )
   IF ( PARSE_GCC_ERRORS )
     #  To let the script know where the source and thus the error parse scripts are sneak in the path as argument.
-    SET_PROPERTY ( GLOBAL PROPERTY RULE_LAUNCH_COMPILE "bash ${CMAKE_CURRENT_SOURCE_DIR}/util/cmakeParseError.sh ${CMAKE_CURRENT_SOURCE_DIR}" )
   ENDIF ( )
 
   # Figure out which GCC version we are using.
@@ -882,7 +884,7 @@ IF ( CMAKE_COMPILER_IS_GNUCXX )
   IF ( NOT ( ${QUOC_GCC_VERSION} VERSION_LESS 4.6 ) )
     #! \cmakeoption{Use C++11,OFF}
     #! \note for gcc compiler version 4.7 or greater or Clang only
-    OPTION ( USE_C++11 "Make the new c++ standard available" OFF )
+    OPTION ( USE_C++11 "Make the new c++ standard available" ON )
     IF ( USE_C++11 )
       # setting CMAKE_CXX_FLAGS does not work
       IF ( ${QUOC_GCC_VERSION} VERSION_LESS 4.7 )

--- a/quocmesh/cmake.selection
+++ b/quocmesh/cmake.selection
@@ -1,0 +1,6 @@
+SET ( SELECTED_MODULES modules/aol modules/quoc )
+SET ( SELECTED_PROJECTS )
+
+SET (SELECTED_STDPROJECTS
+	 selfTest/aol
+	 selfTest/quoc)

--- a/quocmesh/internal/projects/elma/aspectRatioPixmapLabel.cpp
+++ b/quocmesh/internal/projects/elma/aspectRatioPixmapLabel.cpp
@@ -1,4 +1,4 @@
-#include "aspectratiopixmaplabel.hpp"
+#include "aspectRatioPixmapLabel.hpp"
 #include <aol.h>
 
 // Based on AspectRatioPixmapLabel from http://stackoverflow.com/questions/8211982/qt-resizing-a-qlabel-containing-a-qpixmap-while-keeping-its-aspect-ratio

--- a/quocmesh/internal/projects/elma/qcImViewApp.ui
+++ b/quocmesh/internal/projects/elma/qcImViewApp.ui
@@ -350,7 +350,7 @@
   <customwidget>
    <class>AspectRatioPixmapLabel</class>
    <extends>QLabel</extends>
-   <header>aspectratiopixmaplabel.hpp</header>
+   <header>aspectRatioPixmapLabel.hpp</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/quocmesh/internal/projects/elma/qtWorkers.hpp
+++ b/quocmesh/internal/projects/elma/qtWorkers.hpp
@@ -12,7 +12,7 @@
 #include <emNonLocalMeansFilter.h>
 #include <emBM3DFilter.h>
 #include <atomFinder.h>
-#include <aspectratiopixmaplabel.hpp>
+#include <aspectRatioPixmapLabel.hpp>
 
 
 class QtProgressBar;

--- a/quocmesh/modules/aol/geom.h
+++ b/quocmesh/modules/aol/geom.h
@@ -787,14 +787,15 @@ public:
       intersec._pt1[0] = pts[0][0];
       intersec._pt1[1] = pts[0][1];
     }
-    if ( pts.numComponents ( ) == 2 ) {
-      intersec._pt2[0] = pts[1][0];
-      intersec._pt2[1] = pts[1][1];
-    } else {
+    if (pts.numComponents() == 1) {
       intersec._pt2[0] = pts[0][0];
       intersec._pt2[1] = pts[0][1];
     }
-    
+    if ( pts.numComponents ( ) == 2 ) {
+      intersec._pt2[0] = pts[1][0];
+      intersec._pt2[1] = pts[1][1];
+    }
+
     return pts.numComponents ( );
   }
   


### PR DESCRIPTION
* Use C99 and C++11 by default
* Add missing `cmake.selection` file
* Delete call to nonexistant error trap (`cmakeParseError.sh`)
* `modules/aol/geom.h: Intersector::cut()`: Fix the non-intersecting case